### PR TITLE
Exclude static images from the frontend proxy

### DIFF
--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -1,7 +1,8 @@
 import React from 'react';
 import Image from 'next/image';
-import schduleManage from "../../public/images/schedule_manage.jpg";
 import Button from '@/components/Button';
+
+const scheduleManageImage = '/images/schedule_manage.jpg';
 
 const Home: React.FC = () => {
   return (
@@ -26,7 +27,7 @@ const Home: React.FC = () => {
       {/* Right Section */}
       <div className="w-full lg:w-1/2 h-64 lg:h-screen relative">
         <Image
-          src={schduleManage}
+          src={scheduleManageImage}
           alt="スケジュール管理のイメージ"
           fill
           sizes="(max-width: 768px) 100vw, (max-width: 1200px) 50vw, 33vw"

--- a/frontend/src/features/auth/containers/LoginPageContainer.tsx
+++ b/frontend/src/features/auth/containers/LoginPageContainer.tsx
@@ -1,14 +1,15 @@
 import React from 'react';
 import LoginButton from '@/features/auth/components/LoginButton';
-import scheduleManage from '../../../../../public/images/schedule_manage.jpg';
 import Card from '@/components/Card';
+
+const scheduleManageImage = '/images/schedule_manage.jpg';
 
 const LoginPageContainer = () => {
     return (
         <div className="mx-auto max-w-screen-sm p-4 mb-4">
             <Card
                 variant="outlined"
-                image={scheduleManage}
+                image={scheduleManageImage}
             >
                 <h1 className="text-center text-3xl font-extrabold mb-4">
                     Adjusta

--- a/frontend/src/proxy.ts
+++ b/frontend/src/proxy.ts
@@ -57,5 +57,5 @@ export async function proxy(request: NextRequest) {
 }
 
 export const config = {
-    matcher: '/((?!api|_next/static|_next/image|favicon.ico|.*\\.svg$).*)',
+    matcher: '/((?!api|_next/static|_next/image|favicon.ico|.*\\.(?:svg|png|jpg|jpeg|webp|gif)$).*)',
 }


### PR DESCRIPTION
## Overview

- Fix static image handling by serving public images through root-relative paths.
- Exclude common image file extensions from the frontend proxy matcher.

## Background

- Images under `public/images` should be requested as static assets such as `/images/schedule_manage.jpg`.
- The proxy matcher only excluded SVG files, so other image requests could be routed through auth proxy logic unnecessarily.

## Changes

- Replaced direct imports from `public/images` with `/images/schedule_manage.jpg` in the home and login pages.
- Updated the proxy matcher to exclude `svg`, `png`, `jpg`, `jpeg`, `webp`, and `gif` paths.

## Verification

- [x] Ran `git diff --check -- frontend/src/app/page.tsx frontend/src/features/auth/containers/LoginPageContainer.tsx frontend/src/proxy.ts`.
- [x] Ran `npx eslint src/app/page.tsx src/features/auth/containers/LoginPageContainer.tsx src/proxy.ts` from `frontend/`.
- [x] Pushed `fix/frontend-static-image-proxy` to `origin`.

## Impact

- Static image requests are less likely to be intercepted by the auth proxy.
- The home and login pages use public image paths that match Next.js public asset serving.

## Notes

- Created as a draft PR.
- Existing unrelated `frontend/src/lib/server/` worktree changes are not included in this PR.