### PR TITLE
Configure production Cloud Run deployment

### DIFF
--- a/.github/workflows/backend-deploy.yml
+++ b/.github/workflows/backend-deploy.yml
@@ -67,6 +67,9 @@ jobs:
           service: ${{ vars.CLOUD_RUN_SERVICE }}
           region: ${{ vars.GCP_REGION }}
           image: ${{ env.IMAGE }}
+          flags: >-
+            --service-account=${{ vars.CLOUD_RUN_SERVICE_ACCOUNT }}
+            --min-instances=0
           env_vars: |-
             GO_ENV=production
             CORS_ALLOW_ORIGINS=${{ vars.CORS_ALLOW_ORIGINS }}

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -29,7 +29,7 @@
 | Cloud SQL for PostgreSQL | 本格運用 | 同一リージョンでレイテンシ最小・安定。最小構成でも固定費(月 $10〜)が掛かる。Cloud Run からは Cloud SQL コネクタ or プライベート IP |
 | Supabase | Neon 同等 | Auth 等の付随機能は使わない(自前 OAuth があるため)なら Neon とほぼ等価 |
 
-推奨: **まず Neon で開始し、負荷・運用要件が固まったら Cloud SQL を再検討**。
+初回productionは **Neonで開始**し、負荷・運用要件が固まったらCloud SQLを再検討する。
 
 ## 実施時に必要な設定
 
@@ -37,11 +37,11 @@
 
 | 変数 | 置き場所 | 値 |
 | --- | --- | --- |
-| `INTERNAL_BACKEND_URL` | Vercel(server) | Cloud Run の URL(例: `https://adjusta-api-xxxx.a.run.app`) |
+| `INTERNAL_BACKEND_URL` | Vercel(server) | `https://adjusta-api-1001878278191.asia-northeast1.run.app` |
 | `NEXT_PUBLIC_API_BASE_URL` | Vercel | **設定しない**(same-origin proxy を維持) |
 | `SESSION_SECRET` | Cloud Run | 十分に長いランダム値 |
 | DB DSN(`DATABASE_URL` 等、`backend/internal/config` 参照) | Cloud Run | Neon / Cloud SQL の接続文字列 |
-| `CORS_ALLOW_ORIGINS` | Cloud Run | Vercel のドメイン(proxy 経由ならサーバー間通信のため実質不要だが、設定しておく) |
+| `CORS_ALLOW_ORIGINS` | Cloud Run | `https://adjusta.vercel.app` |
 | Google OAuth client ID / secret | Cloud Run | GCP コンソールで発行 |
 
 ### GitHub production environment
@@ -56,6 +56,7 @@ Repository / environment variables:
 | `GCP_REGION` | Artifact Registry / Cloud Runのregion |
 | `GCP_ARTIFACT_REPOSITORY` | Docker repository名 |
 | `CLOUD_RUN_SERVICE` | Cloud Run service名 |
+| `CLOUD_RUN_SERVICE_ACCOUNT` | Cloud Run実行用service accountのメールアドレス |
 | `DATABASE_URL_SECRET` | Secret Manager上のDB接続文字列secret名 |
 | `SESSION_SECRET_SECRET` | Secret Manager上のsession secret名 |
 | `GOOGLE_CLIENT_SECRET_SECRET` | Secret Manager上のOAuth client secret名 |
@@ -63,7 +64,7 @@ Repository / environment variables:
 | `GOOGLE_REDIRECT_URI` | Googleへ登録したcallback URL |
 | `REDIRECT_URL_AFTER_LOGIN` | ログイン完了後のfrontend URL |
 | `CORS_ALLOW_ORIGINS` | 許可するfrontend origin |
-| `COOKIE_DOMAIN` | session cookieのdomain |
+| `COOKIE_DOMAIN` | 空のままにし、Vercel originのhost-only cookieとして扱う |
 
 Environment secrets:
 
@@ -74,15 +75,30 @@ Environment secrets:
 
 長期service account keyは置かず、GitHub OIDCとWorkload Identity Federationを使う。deploy用identityにはArtifact Registryへのpush、Cloud Run更新、DB migration用secretの参照、およびCloud Run実行service accountを利用するための最小権限を付与する。Cloud Runの実行service accountにも、runtimeで参照するSecret Manager secretへのaccessor権限が必要になる。
 
+`production` environmentのdeployment branch policyとWorkload Identity Providerのattribute conditionは、どちらも`main`からの実行だけを許可する。初回本番確認までは`koo-arch`をrequired reviewerとし、個人運用で承認不能にならないようself-reviewは許可する。
+
 ### Google OAuth
 
-- 承認済みリダイレクトURIに **frontendのcallback URL**(`https://<vercel-domain>/api/auth/google/callback`)を登録
+- 承認済みリダイレクトURIに **frontendのcallback URL**(`https://adjusta.vercel.app/api/auth/google/callback`)を登録
 - OAuth 同意画面の公開設定(テストユーザー→本番公開)を確認
 
 ### Cloud Run
 
+Productionで使用するGCPリソースは以下とする。
+
+| 項目 | 値 |
+| --- | --- |
+| Project | `adjusta` |
+| Region | `asia-northeast1` |
+| Cloud Run service | `adjusta-api` |
+| Cloud Run URL | `https://adjusta-api-1001878278191.asia-northeast1.run.app` |
+| Artifact Registry | `adjusta` |
+| Runtime service account | `adjusta-runtime@adjusta.iam.gserviceaccount.com` |
+| Deploy service account | `adjusta-deploy@adjusta.iam.gserviceaccount.com` |
+
 - `backend/Dockerfile` をそのままビルド(GitHub Actions から `gcloud run deploy` が簡単)
 - **min-instances**: 0 だと初回アクセス・OAuth コールバックにコールドスタート遅延が乗る。体感を優先するなら 1(常時課金)。まず 0 で始めて気になったら上げる
+- Cloud Runの実行identityには専用service accountを使用し、workflowの`CLOUD_RUN_SERVICE_ACCOUNT`で明示する
 - cookie の `Secure` / ドメイン設定が本番 URL 前提になっているか `backend/api/cookie` を確認
 
 初回作成時はVercelのserver-side proxyから到達できるようCloud Run invocationのIAMを設定する。workflowはrevisionのデプロイのみを担当し、公開・非公開のIAM設定は変更しない。
@@ -117,7 +133,5 @@ Environment secrets:
 ## 未決事項(実施時に決める)
 
 1. **独自ドメイン**を取るか(取るなら Vercel に割当。backend はブラウザ非公開のため Cloud Run ドメインのままでよい)
-2. **DB の最終選択**(推奨は Neon スタート)
-3. **staging 環境**の要否(Vercel Preview + Cloud Run のリビジョンタグで軽く済ませる案が有力)
-4. Cloud Run の **min-instances**(0 か 1 か)
-5. 初回本番確認後、backend deployを`main` pushで自動実行するか
+2. **staging 環境**の要否(Vercel Preview + Cloud Run のリビジョンタグで軽く済ませる案が有力)
+3. 初回本番確認後、backend deployを`main` pushで自動実行するか

--- a/frontend/src/app/(app)/layout.tsx
+++ b/frontend/src/app/(app)/layout.tsx
@@ -5,6 +5,9 @@ import AuthErrorModal from "@/features/auth/components/AuthErrorModal";
 import UserMenu from "@/features/auth/components/UserMenu";
 import UserMenuSkeleton from "@/features/auth/components/UserMenuSkeleton";
 
+// 認証必須ルートはリクエストごとにセッションを検証するため、静的生成しない。
+export const dynamic = "force-dynamic";
+
 export default function AppLayout({
   children,
 }: Readonly<{


### PR DESCRIPTION
## Overview

- Configure the production Cloud Run deployment to use a dedicated runtime service account.
- Record the provisioned GCP, Neon, Vercel, GitHub OIDC, and production environment settings.
- Render authenticated application routes dynamically so Preview builds do not require a backend connection during prerendering.

## Background

- The deployment workflow would otherwise use the project's default compute service account.
- Production infrastructure values have now been provisioned and need to be reflected in the deployment workflow and operational documentation.
- Vercel Preview failed while prerendering `/events/new` because the authenticated layout called `requireUser` without `INTERNAL_BACKEND_URL`.
- Preview deployments must not connect to the production backend or database.

## Changes

- Deploy Cloud Run revisions with `adjusta-runtime@adjusta.iam.gserviceaccount.com`.
- Keep Cloud Run at zero minimum instances for the initial release.
- Document the production Cloud Run, Artifact Registry, Vercel, Neon, and service account values.
- Document the `main`-only GitHub environment and Workload Identity restrictions.
- Use a host-only session cookie and the deterministic Cloud Run URL.
- Record the production OAuth callback and frontend origin.
- Set the authenticated `(app)` route group to `force-dynamic`.

## Verification

- [x] Parsed `.github/workflows/backend-deploy.yml` as YAML
- [x] `git diff --check`
- [x] Reproduced the Preview failure locally with `INTERNAL_BACKEND_URL` unset
- [x] Confirmed the failure occurred while prerendering `/events/new`
- [x] Confirmed the deterministic Cloud Run URL responds with HTTP 200
- [x] Confirmed unauthenticated invocation is granted through `roles/run.invoker`
- [x] Confirmed the Workload Identity Provider only accepts `koo-arch/adjusta` workflows from `main`
- [x] Confirmed the GitHub `production` environment only permits `main` and requires approval
- [x] Confirmed the Neon connection is direct and reachable
- [x] Confirmed Atlas reports the initial migration as pending
- [x] Confirmed all required Secret Manager versions and GitHub production variables are registered
- [x] The post-fix production build was stopped at the user's request; Vercel Preview will perform the final verification

## Impact

- Future backend deployments use the dedicated runtime identity instead of the default compute service account.
- Production deployment remains manual and approval-gated.
- Authenticated pages render per request instead of being statically generated.
- This PR does not deploy the application backend or apply the pending database migration.

## Notes

- The current Cloud Run revision still serves Google's hello container.
- The OAuth login-start proxy must be fixed in a separate change before deploying and testing the production backend.
- `BACKEND_URL` and browser-facing `NEXT_PUBLIC_API_BASE_URL` will be removed from the login flow in that follow-up.
