### PR TITLE
Proxy OAuth redirects through the frontend

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,14 +126,13 @@ REDIRECT_URL_AFTER_LOGIN=
 ```dotenv
 NEXT_PUBLIC_API_BASE_URL=
 INTERNAL_BACKEND_URL=
-BACKEND_URL=
 ```
 
 補足:
 
 - `NEXT_PUBLIC_API_BASE_URL` は frontend 公開 URL を基準に `/api/*` を呼ぶための base URL です。
 - `INTERNAL_BACKEND_URL` は Next.js サーバー側から backend を呼ぶ URL です。`docker compose` 利用時は `http://backend:8080` を使えます。
-- `BACKEND_URL` は Google ログイン開始時のリダイレクト先に使う backend の公開 URL です。
+- Google OAuthの開始・callbackもNext.jsのRoute Handlerが`INTERNAL_BACKEND_URL`へ中継するため、browser向けのbackend URLは設定しません。
 
 2. 初回起動時、または migration が追加されたときにDB migrationを実行します。
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -14,7 +14,7 @@
 
 ## この構成が本アプリと相性が良い理由(重要)
 
-通常のAPI呼び出しは **Next.js の `/api/[...path]` route handlerがサーバー側でbackendへ転送するproxy構成**になっている(`frontend/src/lib/api/client.ts`のbaseURLは`NEXT_PUBLIC_API_BASE_URL`未設定時に空 = same-origin)。OAuth login開始だけは末尾の「OAuthの既知課題」に記載した実装差分が残る。目標構成は以下とする。
+通常のAPI呼び出しは **Next.js の `/api/[...path]` route handlerがサーバー側でbackendへ転送するproxy構成**になっている(`frontend/src/lib/api/client.ts`のbaseURLは`NEXT_PUBLIC_API_BASE_URL`未設定時に空 = same-origin)。OAuth開始・callbackも専用Route Handlerがbackendのredirectとcookieを中継する。
 
 - **session cookie は Vercel ドメインの first-party のまま** — クロスドメイン cookie / SameSite=None / CORS の問題が発生しない
 - backend(Cloud Run)の URL はブラウザに露出せず、`INTERNAL_BACKEND_URL` としてサーバー側にだけ設定する
@@ -125,10 +125,6 @@ Productionで使用するGCPリソースは以下とする。
 - backend CI: PRでGoテストとAtlas migration整合性検査を実行
 - backend deploy: `Backend Deploy`を手動実行し、Artifact Registryへpush → DB migration適用 → Cloud Run deployの順で実行
 - 初回本番確認が完了するまでは自動deployにせず、GitHub `production` environmentのapprovalを利用する。安定後に`main` push triggerを追加する
-
-### OAuthの既知課題
-
-現状のfrontend login routeはbrowserをCloud Runの`/auth/google/login`へ直接redirectする一方、callbackはVercelのroute handlerを経由する。OAuth state cookieの発行元とcallback時のcookie送信先が一致しない可能性があり、「backend URLをbrowserに露出しない」という上記方針とも実装が一致していない。初回本番OAuth確認前に、login開始もVercel route handler経由でbackendへ問い合わせて`Location`と`Set-Cookie`を転送する形へ統一する必要がある。
 
 ## 未決事項(実施時に決める)
 

--- a/frontend/e2e/fixtures/mock-backend.mjs
+++ b/frontend/e2e/fixtures/mock-backend.mjs
@@ -134,6 +134,37 @@ const server = createServer((request, response) => {
         return;
     }
 
+    if (request.method === 'GET' && request.url === '/auth/google/login') {
+        response.writeHead(307, {
+            Location: `http://localhost:${port}/__e2e/google/authorize`,
+            'Set-Cookie': 'session=oauth-state-session; Path=/; HttpOnly; SameSite=Lax',
+        });
+        response.end();
+        return;
+    }
+
+    if (request.method === 'GET' && request.url === '/__e2e/google/authorize') {
+        response.writeHead(307, {
+            Location: 'http://localhost:3100/api/auth/google/callback?code=e2e-code&state=e2e-state',
+        });
+        response.end();
+        return;
+    }
+
+    if (request.method === 'GET' && request.url?.startsWith('/auth/google/callback?')) {
+        if (sessionToken(request) !== 'oauth-state-session') {
+            json(response, 400, { code: 'bad_request', error: 'stateが不正です' });
+            return;
+        }
+
+        response.writeHead(307, {
+            Location: 'http://localhost:3100/dashboard',
+            'Set-Cookie': 'session=authenticated-session; Path=/; HttpOnly; SameSite=Lax',
+        });
+        response.end();
+        return;
+    }
+
     const expireMatch = request.url?.match(/^\/__e2e\/sessions\/([^/]+)\/expire$/);
     if (request.method === 'POST' && expireMatch) {
         expiredSessions.add(decodeURIComponent(expireMatch[1]));

--- a/frontend/e2e/public/login.spec.ts
+++ b/frontend/e2e/public/login.spec.ts
@@ -6,3 +6,11 @@ test('[PUBLIC-002] ログインページを表示できる', async ({ page }) =>
     await expect(page.getByRole('heading', { name: 'Adjusta' })).toBeVisible();
     await expect(page.getByRole('button', { name: 'Googleでログイン' })).toBeVisible();
 });
+
+test('[PUBLIC-003] Googleログインをsame-origin proxy経由で完了できる', async ({ page }) => {
+    await page.goto('/login');
+    await page.getByRole('button', { name: 'Googleでログイン' }).click();
+
+    await expect(page).toHaveURL('/dashboard');
+    await expect(page.getByRole('heading', { name: 'ホーム' })).toBeVisible();
+});

--- a/frontend/src/app/api/auth/google/callback/route.ts
+++ b/frontend/src/app/api/auth/google/callback/route.ts
@@ -1,31 +1,6 @@
-import { NextResponse } from "next/server";
+import { proxyOAuthRequest } from '@/lib/server/oauthProxy';
 
-export async function GET(req: Request) {
-    // クエリ文字列を取得
-    const { search } = new URL(req.url);
-    // バックエンドのコールバック URL を組み立て
-    const backend = process.env.INTERNAL_BACKEND_URL!;
-    const url = `${backend}/auth/google/callback${search}`;
-
-    //　リダイレクトせずにバックエンドを呼び出し
-    const apiRes = await fetch(url, {
-        method: "GET",
-        headers: {
-            // ブラウザから受け取った Cookie をそのまま渡す
-            cookie: req.headers.get("cookie") || ""
-        },
-        redirect: "manual",
-    });
-
-    // NextResponse でリダイレクト先とステータスを用意
-    const res = NextResponse.redirect(new URL("/", req.url), 307);
-
-    // バックエンドが返した Set-Cookie ヘッダーをすべて転送
-    apiRes.headers.forEach((value, key) => {
-        if (key.toLowerCase() === "set-cookie") {
-            res.headers.append("Set-Cookie", value);
-        }
-    });
-
-    return res;
+export function GET(request: Request) {
+    const { search } = new URL(request.url);
+    return proxyOAuthRequest(request, `/auth/google/callback${search}`);
 }

--- a/frontend/src/app/api/auth/google/login/route.ts
+++ b/frontend/src/app/api/auth/google/login/route.ts
@@ -1,7 +1,5 @@
-import { NextResponse } from 'next/server';
+import { proxyOAuthRequest } from '@/lib/server/oauthProxy';
 
-export function GET() {
-    return NextResponse.redirect(
-        `${process.env.BACKEND_URL}/auth/google/login`
-    );
+export function GET(request: Request) {
+    return proxyOAuthRequest(request, '/auth/google/login');
 }

--- a/frontend/src/features/auth/hooks/useLogin.ts
+++ b/frontend/src/features/auth/hooks/useLogin.ts
@@ -1,9 +1,7 @@
 'use client'
 
 export const useLogin = () => {
-    const baseURL = process.env.NEXT_PUBLIC_API_BASE_URL;
-
     return () => {
-        window.location.href = `${baseURL}/api/auth/google/login`;
+        window.location.assign('/api/auth/google/login');
     };
 };

--- a/frontend/src/lib/server/oauthProxy.ts
+++ b/frontend/src/lib/server/oauthProxy.ts
@@ -1,0 +1,52 @@
+import { NextResponse } from 'next/server';
+
+const redirectStatuses = new Set([301, 302, 303, 307, 308]);
+
+export const proxyOAuthRequest = async (request: Request, path: string) => {
+    const backend = process.env.INTERNAL_BACKEND_URL?.replace(/\/$/, '');
+    if (!backend) {
+        return NextResponse.json(
+            { error: '認証サービスの接続先が設定されていません' },
+            { status: 500 },
+        );
+    }
+
+    try {
+        const backendResponse = await fetch(`${backend}${path}`, {
+            method: 'GET',
+            headers: {
+                cookie: request.headers.get('cookie') ?? '',
+            },
+            redirect: 'manual',
+            cache: 'no-store',
+        });
+
+        const location = backendResponse.headers.get('location');
+        const response =
+            location && redirectStatuses.has(backendResponse.status)
+                ? NextResponse.redirect(location, backendResponse.status)
+                : new NextResponse(backendResponse.body, {
+                      status: backendResponse.status,
+                      statusText: backendResponse.statusText,
+                      headers: {
+                          'content-type':
+                              backendResponse.headers.get('content-type') ??
+                              'application/json',
+                      },
+                  });
+
+        // backendはOAuth stateまたはlogin sessionを1つのcookieとして返す。
+        const setCookie = backendResponse.headers.get('set-cookie');
+        if (setCookie) {
+            response.headers.append('set-cookie', setCookie);
+        }
+
+        return response;
+    } catch (error) {
+        console.error('failed to proxy OAuth request', error);
+        return NextResponse.json(
+            { error: '認証サービスに接続できませんでした' },
+            { status: 502 },
+        );
+    }
+};


### PR DESCRIPTION
## Overview

- Route Google OAuth login and callback traffic through the Next.js frontend.
- Preserve backend redirects and session cookies across the same-origin proxy.

## Background

- The login route previously redirected the browser directly to Cloud Run while the callback used Vercel.
- This split could issue the OAuth state cookie on a different origin and exposed the backend URL to the browser.

## Changes

- Add a shared server-side OAuth proxy for redirect, cookie, and error forwarding.
- Use the proxy from both the Google login and callback Route Handlers.
- Remove the browser-facing backend URL dependency from the login hook and documentation.
- Add an E2E mock OAuth flow and `PUBLIC-003` coverage.

## Verification

- [x] `npx eslint 'src/app/api/auth/google/login/route.ts' 'src/app/api/auth/google/callback/route.ts' 'src/lib/server/oauthProxy.ts' 'src/features/auth/hooks/useLogin.ts' 'e2e/public/login.spec.ts'`
- [x] `npx playwright test e2e/public/login.spec.ts` (2 passed)
- [x] `git diff --check`

## Impact

- Google OAuth state and login session cookies remain first-party on the frontend origin.
- Production no longer needs a browser-facing `BACKEND_URL` frontend variable.

## Notes

- The real production Google OAuth flow still needs verification after the backend is deployed.
- A full production build was not rerun; scoped lint and the affected E2E tests passed.
