### PR TITLE
Pin Atlas revisions for Neon deployments

### DIFF
--- a/.github/workflows/backend-deploy.yml
+++ b/.github/workflows/backend-deploy.yml
@@ -59,7 +59,10 @@ jobs:
           DATABASE_URL_SECRET: ${{ vars.DATABASE_URL_SECRET }}
         run: |
           DATABASE_URL="$(gcloud secrets versions access latest --secret="${DATABASE_URL_SECRET}")"
-          atlas migrate apply --dir "file://backend/migrations" --url "${DATABASE_URL}"
+          atlas migrate apply \
+            --dir "file://backend/migrations" \
+            --url "${DATABASE_URL}" \
+            --revisions-schema "public"
 
       - name: Deploy backend to Cloud Run
         uses: google-github-actions/deploy-cloudrun@v3

--- a/docs/db-design.md
+++ b/docs/db-design.md
@@ -670,7 +670,7 @@ Cloud Runでは新旧revisionが並行してリクエストを処理する可能
 
 アプリケーションテーブルは`public`ではなく`adjusta` schemaへ配置する。ent schemaの共通mixinで`entsql.Schema("adjusta")`を指定し、`sql/schemaconfig`によってruntime queryもschema修飾するため、接続URLの`search_path`には依存しない。
 
-初期migrationでは`public` schemaに対する`PUBLIC` roleの`CREATE`権限を明示的に取り消す。Atlasのmigration履歴はAtlas管理の`atlas_schema_revisions` schemaへ配置される。RLSはtable単位の別機能であり、導入時はmigration ownerとruntime roleの分離、request user IDのtransactionへの設定、policyを別途設計する。
+初期migrationでは`public` schemaに対する`PUBLIC` roleの`CREATE`権限を明示的に取り消す。Atlasのmigration履歴はアプリケーションテーブルとは分離し、ローカルPostgreSQLではdatabase scopeのデフォルトである専用schema、Neon productionでは`--revisions-schema public`を明示して`public.atlas_schema_revisions`で管理する。`public`にはこの履歴テーブル以外のテーブルを置かない。RLSはtable単位の別機能であり、導入時はmigration ownerとruntime roleの分離、request user IDのtransactionへの設定、policyを別途設計する。
 
 ---
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -108,7 +108,8 @@ Productionで使用するGCPリソースは以下とする。
 - Ent Schemaをdesired state、`backend/migrations`配下のSQLをスキーマ変更履歴の正本とする
 - `atlas.sum`はマイグレーションディレクトリの完全性検証に使用し、手動編集せずAtlasのコマンドで更新する
 - 各環境への適用状況はDB上のAtlasリビジョンテーブルで管理する
-- アプリケーションテーブルは`adjusta` schema、Atlasの履歴は`atlas_schema_revisions` schemaへ配置し、`public`にはアプリケーションテーブルを置かない
+- アプリケーションテーブルは`adjusta` schemaへ配置し、`public`にはAtlasの履歴テーブル`atlas_schema_revisions`以外のテーブルを置かない
+- Neon productionではdatabase scopeの履歴schema自動判定が不整合にならないよう、migration適用時は`--revisions-schema public`を明示する。ローカルPostgreSQLはdatabase scopeのデフォルトである専用schemaを使用する
 - ent queryはschema修飾されるため、`DATABASE_URL`へ`search_path`を追加しない
 - schema変更時は`cd backend && atlas migrate diff <name> --env local`でmigrationを生成し、SQLをレビューする
 - ローカル適用は`docker compose --profile tools run --rm migrate`を使う


### PR DESCRIPTION
## Overview

- Pin the Atlas revision table to the PostgreSQL `public` schema for production migrations.
- Document the production-specific Neon behavior separately from local PostgreSQL.

## Background

- The first production deployment failed before applying application migrations.
- Atlas created revision metadata in `public` but attempted to read `atlas_schema_revisions.atlas_schema_revisions` when relying on automatic database-scope detection against Neon.

## Changes

- Pass `--revisions-schema public` to the production `atlas migrate apply` command.
- Keep application tables in the dedicated `adjusta` schema.
- Clarify that `public.atlas_schema_revisions` is metadata and the only table allowed in `public`.
- Keep local PostgreSQL on Atlas's default dedicated revision schema to preserve existing local history.

## Verification

- [x] `git diff --check`
- [x] Confirmed both failed deployments stopped before the Cloud Run deployment step.
- [ ] Re-run `Backend Deploy` after this PR is merged.

## Impact

- Production migration history uses an explicit, stable schema on Neon.
- Application data placement and runtime Ent queries remain unchanged.

## Notes

- No migration SQL or application code was changed.
- Failed deployment runs: `29267438347` and `29282910388`.
