### PR TITLE
Use SameSite Lax for session cookies

### DIFF
--- a/backend/api/cookie/cookie.go
+++ b/backend/api/cookie/cookie.go
@@ -33,7 +33,7 @@ func (m *Manager) Options() sessions.Options {
 		MaxAge:   defaultMaxAge,
 		HttpOnly: true,
 		Secure:   m.secure,
-		SameSite: m.sameSite(),
+		SameSite: http.SameSiteLaxMode,
 	}
 }
 
@@ -46,13 +46,6 @@ func (m *Manager) Expired(name string) *http.Cookie {
 		Domain:   m.domain,
 		HttpOnly: true,
 		Secure:   m.secure,
-		SameSite: m.sameSite(),
+		SameSite: http.SameSiteLaxMode,
 	}
-}
-
-func (m *Manager) sameSite() http.SameSite {
-	if m.secure {
-		return http.SameSiteNoneMode
-	}
-	return http.SameSiteLaxMode
 }

--- a/backend/api/cookie/cookie_test.go
+++ b/backend/api/cookie/cookie_test.go
@@ -1,0 +1,32 @@
+package cookie
+
+import (
+	"net/http"
+	"testing"
+)
+
+func TestManagerUsesSameSiteLax(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		secure bool
+	}{
+		{name: "local", secure: false},
+		{name: "production", secure: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			manager := NewManager("", tt.secure)
+			if got := manager.Options().SameSite; got != http.SameSiteLaxMode {
+				t.Fatalf("session cookie SameSite = %v, want %v", got, http.SameSiteLaxMode)
+			}
+			if got := manager.Expired(SessionCookieName).SameSite; got != http.SameSiteLaxMode {
+				t.Fatalf("expired cookie SameSite = %v, want %v", got, http.SameSiteLaxMode)
+			}
+		})
+	}
+}

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -17,6 +17,7 @@
 通常のAPI呼び出しは **Next.js の `/api/[...path]` route handlerがサーバー側でbackendへ転送するproxy構成**になっている(`frontend/src/lib/api/client.ts`のbaseURLは`NEXT_PUBLIC_API_BASE_URL`未設定時に空 = same-origin)。OAuth開始・callbackも専用Route Handlerがbackendのredirectとcookieを中継する。
 
 - **session cookie は Vercel ドメインの first-party のまま** — クロスドメイン cookie / SameSite=None / CORS の問題が発生しない
+- session cookieは`HttpOnly`・`Secure`・host-only・`SameSite=Lax`とし、OAuth callbackを含む認証導線もsame-origin proxy経由で扱う
 - backend(Cloud Run)の URL はブラウザに露出せず、`INTERNAL_BACKEND_URL` としてサーバー側にだけ設定する
 - 本番では **`NEXT_PUBLIC_API_BASE_URL` は未設定(空)のままにする**こと。値を入れるとブラウザ直アクセスになり、上記の利点が崩れる
 - OAuth開始・callbackも`/api/auth/*`のroute handler経由へ統一する(`frontend/src/app/api/`)

--- a/docs/rearchitecture-memo.md
+++ b/docs/rearchitecture-memo.md
@@ -72,7 +72,7 @@
 
 - cookie は session cookie のみを採用する
 - `access_token` cookie や `refresh_token` cookie は採用しない
-- session cookie は `HttpOnly` を前提とし、`Secure` / `SameSite` は環境ごとの設定で管理する
+- session cookie は `HttpOnly` を前提とし、`Secure` は環境ごとに設定する。`SameSite` はfrontendのsame-origin proxyを前提に`Lax`へ固定する
 - frontend は cookie の中身を認証の「判定」に使わない。proxy(middleware)は cookie の存在だけを見る楽観的ルーティング(UX)に徹し、権威的な認証判定は Go API のセッション検証に集約する(詳細は 4.1.8)
 
 #### 4.1.4 ログインフローの最終形


### PR DESCRIPTION
## Overview

- Set Adjusta session cookies to `SameSite=Lax` in every environment.
- Cover both active and expired cookie options with unit tests.

## Background

- Production cookies were emitted with `SameSite=None` whenever `Secure` was enabled.
- OAuth login and callback now use the frontend same-origin proxy, so cross-site cookie delivery is no longer required.

## Changes

- Use `http.SameSiteLaxMode` for session issuance, renewal, and expiration.
- Add tests for local and production cookie manager configurations.
- Document the same-origin cookie policy in deployment and architecture guidance.

## Verification

- [x] `env GOCACHE=/tmp/adjusta-go-build go test ./...`
- [x] `env GOCACHE=/tmp/adjusta-go-build go test ./api/cookie/...`
- [x] `git diff --check`

## Impact

- Session cookies are no longer sent in unnecessary cross-site contexts.
- Google OAuth continues to work because the callback is a top-level navigation through the frontend origin.

## Notes

- After deployment, confirm the production `Set-Cookie` header contains `SameSite=Lax` and repeat the Google login flow.
