### PR TITLE
Fix proposed date priority order

### DIFF
--- a/frontend/e2e/events/detail.spec.ts
+++ b/frontend/e2e/events/detail.spec.ts
@@ -13,8 +13,10 @@ test('[EVENT-014] イベント詳細と候補日程を表示できる', async ({
     await expect(page.getByText('会議室A')).toBeVisible();
     await expect(page.getByText('イベント詳細の説明')).toBeVisible();
     await expect(page.getByRole('heading', { name: '候補日程' })).toBeVisible();
-    await expect(page.getByLabel('第1候補')).toBeVisible();
-    await expect(page.getByText('未同期', { exact: true })).toBeVisible();
+    await expect(page.getByLabel('第1候補').locator('..')).toContainText('7月22日(水) 1:00 - 2:00');
+    await expect(page.getByLabel('第2候補').locator('..')).toContainText('7月21日(火) 1:00 - 2:00');
+    await expect(page.getByLabel('第3候補').locator('..')).toContainText('7月20日(月) 1:00 - 2:00');
+    await expect(page.getByText('未同期', { exact: true }).first()).toBeVisible();
 });
 
 test('[EVENT-015] 存在しないイベントでは404表示になる', async ({

--- a/frontend/e2e/fixtures/mock-backend.mjs
+++ b/frontend/e2e/fixtures/mock-backend.mjs
@@ -321,10 +321,26 @@ const server = createServer((request, response) => {
             location: '会議室A',
             proposed_dates: [
                 {
+                    id: 'candidate-3',
+                    start: '2026-07-22T01:00:00.000Z',
+                    end: '2026-07-22T02:00:00.000Z',
+                    priority: 3072,
+                    status: 'active',
+                    sync_status: 'not_synced',
+                },
+                {
+                    id: 'candidate-2',
+                    start: '2026-07-21T01:00:00.000Z',
+                    end: '2026-07-21T02:00:00.000Z',
+                    priority: 2048,
+                    status: 'active',
+                    sync_status: 'not_synced',
+                },
+                {
                     id: 'candidate-1',
                     start: '2026-07-20T01:00:00.000Z',
                     end: '2026-07-20T02:00:00.000Z',
-                    priority: 1,
+                    priority: 1024,
                     status: 'active',
                     sync_status: 'not_synced',
                 },

--- a/frontend/src/features/events/detail/components/ProposedDatesSection.tsx
+++ b/frontend/src/features/events/detail/components/ProposedDatesSection.tsx
@@ -15,7 +15,7 @@ interface ProposedDatesSectionProps {
 }
 
 const sortByPriority = (dates: EventProposedDate[]) =>
-    [...dates].sort((a, b) => a.priority - b.priority);
+    [...dates].sort((a, b) => b.priority - a.priority);
 
 // 相手にそのまま貼れるテキスト(要件 5.6: 初期リリースの共有主導線)
 const buildCopyText = (title: string, dates: EventProposedDate[]) =>


### PR DESCRIPTION
## Overview

- Display proposed dates in descending priority order on the event detail page.
- Add an E2E regression check for the displayed first, second, and third candidates.

## Background

- Higher numeric `priority` values represent higher-priority proposed dates.
- The backend already returned proposed dates in descending order, but the detail component sorted them again in ascending order. This made the lowest-priority date appear as the first candidate and also reversed the copied candidate list.

## Changes

- Changed the event-detail priority comparator to sort higher values first.
- Expanded the detail E2E fixture to include three distinct priority values.
- Asserted that candidate labels follow `3072 -> 2048 -> 1024` priority order.

## Verification

- [x] `npm run build`
- [x] ESLint on the changed frontend files
- [x] `npm run test:e2e -- e2e/events/detail.spec.ts`
- [x] `git diff --check`

## Impact

- Event-detail display and clipboard output now match the documented priority semantics.
- Backend APIs and the database schema are unchanged.

## Notes

- Initial local Playwright attempts were interrupted by environment memory pressure; the E2E suite passed after memory was released.
